### PR TITLE
Update Get-CMClientBaselineEvaluation.ps1

### DIFF
--- a/Get-CMClientBaselineEvaluation.ps1
+++ b/Get-CMClientBaselineEvaluation.ps1
@@ -46,48 +46,54 @@ function Get-CMClientBaselineEvaluation
                    Position=0)]
         [string[]]$ComputerName=$env:COMPUTERNAME
     )
+
+
     begin {
         $ComplianceHash = [hashtable]@{
-                                "0" = 'Non-Compliant'
-                                "1" = 'Compliant'
-                                "2" = 'Submitted'
-                                "3" = 'Unknown'
-                                "4" = 'Detecting'
-                                "5" = 'Not Evaluated'                  
-                        }  
+            "0" = 'Non-Compliant'
+            "1" = 'Compliant'
+            "2" = 'Submitted'
+            "3" = 'Unknown'
+            "4" = 'Detecting'
+            "5" = 'Not Evaluated'                  
+        }  
         $EvalHash = [hashtable]@{
-                                "0" = 'Idle'
-                                "1" = 'Evaluated'
-                                "5" = 'Not Evaluated'                                   
-                        } 
+            "0"  = 'Idle'
+            "1"  = 'Evaluated'
+            "5"  = 'Not Evaluated'
+            "99" = 'Unknown'
+        } 
     
-        }
+    }
     process {
         foreach ($Computer in $ComputerName) {
             # Get a list of baseline objects assigned to the remote computer
-            $Baselines = Get-WmiObject -ComputerName $Computer -Namespace root\ccm\dcm -Class SMS_DesiredConfiguration
+            $Baselines = Get-WmiObject -ComputerName $Computer -Namespace root\ccm\dcm -Class SMS_DesiredConfiguration | Sort-Object DisplayName
 
             # For each (%) baseline object, call SMS_DesiredConfiguration.TriggerEvaluation, passing in the Name and Version as params
             foreach ($Baseline in $Baselines) {
                 if ($Baseline.LastEvalTime -eq '00000000000000.000000+000') {
                     $LastEvalTime = 'N/A'
-                    } 
+                } 
                 else {
                     $LastEvalTime = $Baseline.ConvertToDateTime($Baseline.LastEvalTime)
-                    }
-                $BaselineStatusProperties = [ordered]@{
+                }
+
+
+                $BaselineStatus = [pscustomobject]@{
                     ComputerName = $Baseline.PSComputerName
                     BaselineName = $Baseline.DisplayName
                     Version = $Baseline.Version
-                    EvaluationStatus = $EvalHash[$Baseline.Status.tostring()]
+                    EvaluationStatus = if ($null -eq $Baseline.Status) { $EvalHash['99'] } else { $EvalHash[$Baseline.Status.ToString()] }
                     Compliance = $ComplianceHash[$Baseline.LastComplianceStatus.tostring()]
                     LastEvaluationTime = $LastEvalTime
-                    }
-                $BaselineStatus = New-Object -TypeName pscustomobject -Property $BaselineStatusProperties
-                $BaselineStatus
                 }
+                
+                $BaselineStatus
             }
         }
+    }
+
     end {}
     
 }


### PR DESCRIPTION
Handling of empty / missing Status on baseline
Minor stylistic changes
Include sorting of baselines by DisplayName for consistent output
Change hashtable / [ordered] to [pscustomobject] for consciceness, may have to be reverted for pre 5.1 compatibility. Have not tested.